### PR TITLE
Support for StackExchange.Redis version 2.6.90

### DIFF
--- a/samples/RedisConnectionPoolConsoleApp/RedisConnectionPoolConsoleApp.csproj
+++ b/samples/RedisConnectionPoolConsoleApp/RedisConnectionPoolConsoleApp.csproj
@@ -2,11 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\StackExchange.Redis.MultiplexerPool\StackExchange.Redis.MultiplexerPool.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/StackExchange.Redis.MultiplexerPool/Multiplexers/InternalDisposableConnectionMultiplexer.cs
+++ b/src/StackExchange.Redis.MultiplexerPool/Multiplexers/InternalDisposableConnectionMultiplexer.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Net;
 using System.Threading.Tasks;
+using StackExchange.Redis.Maintenance;
 using StackExchange.Redis.MultiplexerPool.Infra.Common;
 using StackExchange.Redis.Profiling;
 
@@ -21,6 +22,10 @@ namespace StackExchange.Redis.MultiplexerPool.Multiplexers
 
         /// <inheritdoc />
         public void Dispose()
+            => throw CreateDisposeNotAllowedException();
+        
+        /// <inheritdoc />
+        public ValueTask DisposeAsync()
             => throw CreateDisposeNotAllowedException();
 
         /// <inheritdoc />
@@ -87,6 +92,10 @@ namespace StackExchange.Redis.MultiplexerPool.Multiplexers
         /// <inheritdoc />
         public IServer GetServer(EndPoint endpoint, object asyncState = null)
             => _wrappedConnectionMultiplexer.GetServer(endpoint, asyncState);
+
+        /// <inheritdoc />
+        public IServer[] GetServers()
+            => _wrappedConnectionMultiplexer.GetServers();
 
 
         /// <inheritdoc />
@@ -231,6 +240,12 @@ namespace StackExchange.Redis.MultiplexerPool.Multiplexers
         {
             add => _wrappedConnectionMultiplexer.ConfigurationChangedBroadcast += value;
             remove => _wrappedConnectionMultiplexer.ConfigurationChangedBroadcast -= value;
+        }
+
+        public event EventHandler<ServerMaintenanceEvent> ServerMaintenanceEvent
+        {
+            add => _wrappedConnectionMultiplexer.ServerMaintenanceEvent += value;
+            remove => _wrappedConnectionMultiplexer.ServerMaintenanceEvent -= value;
         }
 
         /// <inheritdoc />

--- a/src/StackExchange.Redis.MultiplexerPool/StackExchange.Redis.MultiplexerPool.csproj
+++ b/src/StackExchange.Redis.MultiplexerPool/StackExchange.Redis.MultiplexerPool.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.0.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.2.79" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.90" />
   </ItemGroup>
 
 </Project>

--- a/tests/StackExchange.Redis.MultiplexerPool.Tests/StackExchange.Redis.MultiplexerPool.Tests.csproj
+++ b/tests/StackExchange.Redis.MultiplexerPool.Tests/StackExchange.Redis.MultiplexerPool.Tests.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.9.0" />
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.11.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />


### PR DESCRIPTION
Newer redis versions added GetServers and DisposeAsync functions to IConnectionMultiplexer interface. Added support for these functions for your version of multiplexer